### PR TITLE
Potential improvement on naming and discoverability.

### DIFF
--- a/RadialUIPlugin/RadialCheckRemove.cs
+++ b/RadialUIPlugin/RadialCheckRemove.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace RadialUI
+{
+	public delegate bool ShouldShowMenu(string menuText, string miniId, string targetId);
+	public class RadialCheckRemove
+	{
+		public string TitleToRemove { get; set; }
+		public ShouldShowMenu ShouldRemoveCallback { get; }
+
+		public RadialCheckRemove()
+		{
+
+		}
+
+		public RadialCheckRemove(string titleToRemove, ShouldShowMenu shouldRemoveCallback)
+		{
+			TitleToRemove = titleToRemove;
+			ShouldRemoveCallback = shouldRemoveCallback;
+		}
+	}
+}

--- a/RadialUIPlugin/RadialExtensions.cs
+++ b/RadialUIPlugin/RadialExtensions.cs
@@ -14,14 +14,37 @@ namespace RadialUI
 
 		public static string GetTitle(this MapMenuItem mapMenuItem)
 		{
+			if (mapMenuItem == null)
+				return null;
 			FieldInfo mapField = mapMenuItem.GetType().GetField("_title", bindFlags);
+			if (mapField == null)
+			{
+				GameObject TXT_Title = mapMenuItem.gameObject.FindChild("TXT_Title");
+				if (TXT_Title != null)
+				{
+					Component textMeshProUGUI = TXT_Title.GetComponent("TextMeshProUGUI");
+					if (textMeshProUGUI != null)
+					{
+						PropertyInfo textProperty = textMeshProUGUI.GetType().GetProperty("text", bindFlags);
+						if (textProperty != null)
+							return textProperty.GetValue(textMeshProUGUI) as string;
+					}
+				}
+				return null;
+			}
 			return (string)mapField.GetValue(mapMenuItem);
 		}
 
 		public static string GetTitle(this MapMenu mapMenu)
 		{
+			if (mapMenu == null)
+				return null;
 			Transform transform = mapMenu.transform.GetChild(0).GetChild(0);
 			MapMenuItem mapComponent = transform.GetComponent<MapMenuItem>();
+			if (mapComponent == null)
+				mapComponent = transform.GetComponent<MapMenuStatItem>();
+			if (mapComponent == null)
+				return null;
 			return mapComponent.GetTitle();
 		}
 
@@ -37,6 +60,30 @@ namespace RadialUI
 				FadeName = mapArgs.FadeName,
 				Obj = mapArgs.Obj,
 			};
+		}
+
+		public static GameObject FindChild(this GameObject gameObject, string name, bool includeInactive = false)
+		{
+			Transform[] childTransforms = gameObject.GetComponentsInChildren<Transform>(includeInactive);
+			RectTransform[] rectTransforms = gameObject.GetComponentsInChildren<RectTransform>(includeInactive);
+
+			if (childTransforms != null)
+				foreach (Transform transform in childTransforms)
+				{
+					GameObject child = transform.gameObject;
+					if (child?.name == name)
+						return child;
+				}
+
+			if (rectTransforms != null)
+				foreach (Transform transform in rectTransforms)
+				{
+					GameObject child = transform.gameObject;
+					if (child?.name == name)
+						return child;
+				}
+
+			return null;
 		}
 	}
 }

--- a/RadialUIPlugin/RadialExtensions.cs
+++ b/RadialUIPlugin/RadialExtensions.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RadialUI
+{
+	public static class RadialExtensions
+	{
+		private const BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+		public static string GetTitle(this MapMenuItem mapMenuItem)
+		{
+			FieldInfo mapField = mapMenuItem.GetType().GetField("_title", bindFlags);
+			return (string)mapField.GetValue(mapMenuItem);
+		}
+
+		public static string GetTitle(this MapMenu mapMenu)
+		{
+			Transform transform = mapMenu.transform.GetChild(0).GetChild(0);
+			MapMenuItem mapComponent = transform.GetComponent<MapMenuItem>();
+			return mapComponent.GetTitle();
+		}
+
+		public static MapMenu.ItemArgs Clone(this MapMenu.ItemArgs mapArgs)
+		{
+			return new MapMenu.ItemArgs
+			{
+				Title = mapArgs.Title,
+				Icon = mapArgs.Icon,
+				CloseMenuOnActivate = mapArgs.CloseMenuOnActivate,
+				ValueText = mapArgs.ValueText,
+				SubValueText = mapArgs.SubValueText,
+				FadeName = mapArgs.FadeName,
+				Obj = mapArgs.Obj,
+			};
+		}
+	}
+}

--- a/RadialUIPlugin/RadialSubmenu.cs
+++ b/RadialUIPlugin/RadialSubmenu.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine;
-using TaleSpireCore;
-using BepInEx;
 using Bounce.Unmanaged;
 using System.Collections.Generic;
 using System;

--- a/RadialUIPlugin/RadialSubmenu.cs
+++ b/RadialUIPlugin/RadialSubmenu.cs
@@ -1,302 +1,279 @@
 ﻿using UnityEngine;
+using TaleSpireCore;
 using BepInEx;
 using Bounce.Unmanaged;
 using System.Collections.Generic;
 using System;
-using System.Reflection;
 
 namespace RadialUI
 {
-    public class RadialSubmenu
-    {
-        // Radial menu selected asset
-        private static CreatureGuid radialAsset = CreatureGuid.Empty;
-        private static HideVolumeItem radialHideVolume;
+	public class RadialSubmenu
+	{
+		// Radial menu selected asset
+		private static CreatureGuid radialAsset = CreatureGuid.Empty;
+		private static HideVolumeItem radialHideVolume;
 
-        // Hold sub-entries for main menus
-        private static Dictionary<string, List<MapMenu.ItemArgs>> subMenuEntries = new Dictionary<string, List<MapMenu.ItemArgs>>();
+		// Hold sub-entries for main menus
+		private static Dictionary<string, List<MapMenu.ItemArgs>> subMenuEntries = new Dictionary<string, List<MapMenu.ItemArgs>>();
 
-        private static Dictionary<MapMenu.ItemArgs, Func<bool>> subMenuChecker =
-            new Dictionary<MapMenu.ItemArgs, Func<bool>>();
+		private static Dictionary<MapMenu.ItemArgs, Func<bool>> subMenuChecker =
+				new Dictionary<MapMenu.ItemArgs, Func<bool>>();
 
-        /// <summary>
-        /// Enumeration for the type of menu. Hidden volumes are not currently supported since their callback is a little
-        /// different but they could be added with a little bit of extra effort
-        /// </summary>
-        public enum MenuType
-        {
-            character = 1,
-            canAttack,
-            cantAttack,
-            HideVolume,
-        }
+		/// <summary>
+		/// Enumeration for the type of menu. Hidden volumes are not currently supported since their callback is a little
+		/// different but they could be added with a little bit of extra effort
+		/// </summary>
+		public enum MenuType
+		{
+			character = 1,
+			canAttack,
+			cantAttack,
+			HideVolume,
+		}
 
-        private static MenuType openMenuType = MenuType.character;
+		private static MenuType openMenuType = MenuType.character;
 
-        /*
-        /// <inheritdoc cref="EnsureMainMenuItem(string,RadialUI.RadialSubmenu.MenuType,string,UnityEngine.Sprite,System.Func{Bounce.Unmanaged.NGuid,Bounce.Unmanaged.NGuid,bool})"/>
-        public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon,
-            Func<NGuid, NGuid, bool> callback) => EnsureMainMenuItem(mainGuid, type, title, icon, callback,null);
+		/*
+		/// <inheritdoc cref="EnsureMainMenuItem(string,RadialUI.RadialSubmenu.MenuType,string,UnityEngine.Sprite,System.Func{Bounce.Unmanaged.NGuid,Bounce.Unmanaged.NGuid,bool})"/>
+		public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon,
+				Func<NGuid, NGuid, bool> callback) => EnsureMainMenuItem(mainGuid, type, title, icon, callback,null);
 
-        /// <inheritdoc cref="EnsureMainMenuItem(string,RadialUI.RadialSubmenu.MenuType,string,UnityEngine.Sprite,System.Func{HideVolumeItem,bool})"/>
-        public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon,
-            Func<HideVolumeItem, bool> callback) => EnsureMainMenuItem(mainGuid, type, title, icon, null, callback);*/
+		/// <inheritdoc cref="EnsureMainMenuItem(string,RadialUI.RadialSubmenu.MenuType,string,UnityEngine.Sprite,System.Func{HideVolumeItem,bool})"/>
+		public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon,
+				Func<HideVolumeItem, bool> callback) => EnsureMainMenuItem(mainGuid, type, title, icon, null, callback);*/
 
-        /// <summary>
-        /// Method that a plugin uses to ensure that the desired main (radial) menu item exits.
-        /// The method creates the entry if it does not exists and ignore the requested if it already exists.
-        /// For multiple plugins to share a main menu entry, they need to use the same guid.
-        /// </summary>
-        /// <param name="mainGuid">Guid for the main menu entry</param>
-        /// <param name="type">Determines which type of radial menu the entry is for</param>
-        /// <param name="title">Text that is associated with the entry</param>
-        /// <param name="icon">Icon that should be displayed</param>
-        /// <param name="creatureCallback">callback for a creature</param>
-        /// <param name="hideVolumeCallback">callback for a hide volume</param>
-        public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon) // , Func<NGuid, NGuid, bool> creatureCallback = null, Func<HideVolumeItem, bool> hideVolumeCallback = null )
-        {
-            // Don't create the main menu entry multiple times
-            if (subMenuEntries.ContainsKey(mainGuid)) { return; }
-            // Create the main menu entry based on the type of menu
-            switch (type)
-            {
-                case MenuType.character:
-                    RadialUI.RadialUIPlugin.AddOnCharacter(mainGuid, new MapMenu.ItemArgs()
-                    {
-                        // Add mainGuid into the callback so we can look up the corresponding sub-menu entries
-                        Action = (mmi, obj) => { DisplaySubmenu(mmi, obj, mainGuid); },
-                        Icon = icon,
-                        Title = title,
-                        CloseMenuOnActivate = false
-                    }, Reporter);
-                    openMenuType = MenuType.character;
-                    break;
-                case MenuType.canAttack:
-                    RadialUI.RadialUIPlugin.AddOnCanAttack(mainGuid, new MapMenu.ItemArgs()
-                    {
-                        // Add mainGuid into the callback so we can look up the corresponding sub-menu entries
-                        Action = (mmi, obj) => { DisplaySubmenu(mmi, obj, mainGuid); },
-                        Icon = icon,
-                        Title = title,
-                        CloseMenuOnActivate = false
-                    }, Reporter);
-                    openMenuType = MenuType.character;
-                    break;
-                case MenuType.cantAttack:
-                    RadialUI.RadialUIPlugin.AddOnCantAttack(mainGuid, new MapMenu.ItemArgs()
-                    {
-                        // Add mainGuid into the callback so we can look up the corresponding sub-menu entries
-                        Action = (mmi, obj) => { DisplaySubmenu(mmi, obj, mainGuid); },
-                        Icon = icon,
-                        Title = title,
-                        CloseMenuOnActivate = false
-                    }, Reporter);
-                    openMenuType = MenuType.character;
-                    break;
-                case MenuType.HideVolume:
-                    RadialUI.RadialUIPlugin.AddOnHideVolume(mainGuid, new MapMenu.ItemArgs()
-                    {
-                        // Add mainGuid into the callback so we can look up the corresponding sub-menu entries
-                        Action = (mmi, obj) => { DisplaySubmenu(mmi, obj, mainGuid); },
-                        Icon = icon,
-                        Title = title,
-                        CloseMenuOnActivate = false
-                    }, Reporter);
-                    openMenuType = MenuType.HideVolume;
-                    break;
-            }
-            // Add a list into the dictionary to hold sub-menu entries for the main menu entry
-            // (Presence of an entry in this dictionary means the main menu entry has already been created)
-            subMenuEntries.Add(mainGuid, new List<MapMenu.ItemArgs>());
-        }
+		/// <summary>
+		/// Method that a plugin uses to ensure that the desired main (radial) menu item exits.
+		/// The method creates the entry if it does not exists and ignore the requested if it already exists.
+		/// For multiple plugins to share a main menu entry, they need to use the same guid.
+		/// </summary>
+		/// <param name="mainGuid">Guid for the main menu entry</param>
+		/// <param name="type">Determines which type of radial menu the entry is for</param>
+		/// <param name="title">Text that is associated with the entry</param>
+		/// <param name="icon">Icon that should be displayed</param>
+		public static void EnsureMainMenuItem(string mainGuid, MenuType type, string title, Sprite icon)
+		{
+			// Don't create the main menu entry multiple times
+			if (subMenuEntries.ContainsKey(mainGuid)) { return; }
+			// Create the main menu entry based on the type of menu
+			switch (type)
+			{
+				case MenuType.character:
+					EnsureMainMenuOnCharacter(mainGuid, title, icon);
+					break;
+				case MenuType.canAttack:
+					EnsureMainMenuOnCanAttack(mainGuid, title, icon);
+					break;
+				case MenuType.cantAttack:
+					EnsureMainMenuOnCantAttack(mainGuid, title, icon);
+					break;
+				case MenuType.HideVolume:
+					EnsureMainMenuOnHideVolume(mainGuid, title, icon);
+					break;
+			}
+			// Add a list into the dictionary to hold sub-menu entries for the main menu entry
+			// (Presence of an entry in this dictionary means the main menu entry has already been created)
+			subMenuEntries.Add(mainGuid, new List<MapMenu.ItemArgs>());
+		}
 
-        [Obsolete]
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon,
-            Action<CreatureGuid, string, MapMenuItem> callback, bool closeMenu)
-        {
-            CreateSubMenuItem(mainGuid,title,icon,callback,closeMenu,null);
-        }
-        
-        [Obsolete]
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon,
-            Action<CreatureGuid, string, MapMenuItem> callback)
-        {
-            CreateSubMenuItem(mainGuid, title, icon, callback, true, null);
-        }
+		private static void EnsureMainMenuOnHideVolume(string mainGuid, string title, Sprite icon)
+		{
+			RadialUIPlugin.AddOnHideVolume(mainGuid, NewMainMenu(mainGuid, title, icon), Reporter);
+			openMenuType = MenuType.HideVolume;
+		}
 
-        /// <summary>
-        /// Add sub-menu items to a maim menu entry
-        /// </summary>
-        /// <param name="mainGuid">Guid of the main menu entry</param>
-        /// <param name="title">Text associated with the sub-menu item</param>
-        /// <param name="icon">Icon associated with the sub-menu item</param>
-        /// <param name="callback">Callback that is called when the sub-menu item is selected</param>
-        /// <param name="closeMenu">Determines if the menu is closed after sub-menu item is selected</param>
-        /// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<CreatureGuid, string, MapMenuItem> callback, bool closeMenu = true, Func<bool> checker= null)
-        {
-            // Check if the main menu Guid exists
-            if (!subMenuEntries.ContainsKey(mainGuid))
-            {
-                Debug.LogWarning("Main radial menu '" + mainGuid + "' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
-                return;
-            }
-            // Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
-            var item = new MapMenu.ItemArgs
-            {
-                // Parent plugin specified callback for when the sub-menu item is selected
-                Action = (mmi, obj) => { callback(radialAsset, mainGuid, mmi); },
-                Icon = icon,
-                Title = title,
-                CloseMenuOnActivate = closeMenu
-            };
-            subMenuEntries[mainGuid].Add(item);
-            if (checker != null) subMenuChecker.Add(item, checker);
-        }
+		private static void EnsureMainMenuOnCantAttack(string mainGuid, string title, Sprite icon)
+		{
+			RadialUIPlugin.AddOnCantAttack(mainGuid, NewMainMenu(mainGuid, title, icon), Reporter);
+			openMenuType = MenuType.character;
+		}
 
-        /// <summary>
-        /// Add sub-menu items to a maim menu entry
-        /// </summary>
-        /// <param name="mainGuid">Guid of the main menu entry</param>
-        /// <param name="title">Text associated with the sub-menu item</param>
-        /// <param name="icon">Icon associated with the sub-menu item</param>
-        /// <param name="callback">Callback that is called when the sub-menu item is selected</param>
-        /// <param name="closeMenu">Determines if the menu is closed after sub-menu item is selected</param>
-        /// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
-        public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<HideVolumeItem, string, MapMenuItem> callback, bool closeMenu = true, Func<bool> checker = null)
-        {
-            // Check if the main menu Guid exists
-            if (!subMenuEntries.ContainsKey(mainGuid))
-            {
-                Debug.LogWarning("Main radial menu '" + mainGuid + "' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
-                return;
-            }
-            // Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
-            var item = new MapMenu.ItemArgs
-            {
-                // Parent plugin specified callback for when the sub-menu item is selected
-                Action = (mmi, obj) => { callback(radialHideVolume, mainGuid, mmi); },
-                Icon = icon,
-                Title = title,
-                CloseMenuOnActivate = closeMenu
-            };
-            subMenuEntries[mainGuid].Add(item);
-            if (checker != null) subMenuChecker.Add(item, checker);
-        }
+		private static void EnsureMainMenuOnCanAttack(string mainGuid, string title, Sprite icon)
+		{
+			RadialUIPlugin.AddOnCanAttack(mainGuid, NewMainMenu(mainGuid, title, icon), Reporter);
+			openMenuType = MenuType.character;
+		}
 
-        /// <summary>
-        /// Add sub-menu items to a maim menu entry
-        /// </summary>
-        /// <param name="mainGuid">Guid of the main menu entry</param>
-        /// <param name="item">Uses standard mapmenu item args for greater flexibility</param>
-        /// <param name="callback">Callback that is called when the sub-menu item is selected if you want 3 parameter return</param>
-        /// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
-        public static void CreateSubMenuItem(string mainGuid, MapMenu.ItemArgs item , Action<HideVolumeItem, string, MapMenuItem> callback = null, Func<bool> checker = null)
-        {
-            // Check if the main menu Guid exists
-            if (!subMenuEntries.ContainsKey(mainGuid))
-            {
-                Debug.LogWarning("Main radial menu '" + mainGuid + "' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
-                return;
-            }
+		private static void EnsureMainMenuOnCharacter(string mainGuid, string title, Sprite icon)
+		{
+			RadialUIPlugin.AddOnCharacter(mainGuid, NewMainMenu(mainGuid, title, icon), Reporter);
+			openMenuType = MenuType.character;
+		}
 
-            if (callback != null) item.Action = (mmi, obj) => { callback(radialHideVolume, mainGuid, mmi); };
+		public static MapMenu.ItemArgs NewMainMenu(string mainGuid, string title, Sprite icon)
+		{
+			return new MapMenu.ItemArgs()
+			{
+				// Add mainGuid into the callback so we can look up the corresponding sub-menu entries
+				Action = (mmi, obj) => { DisplaySubmenu(mmi, obj, mainGuid); },
+				Icon = icon,
+				Title = title,
+				CloseMenuOnActivate = false
+			};
+		}
 
-            // Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
-            subMenuEntries[mainGuid].Add(item);
-            if (checker != null) subMenuChecker.Add(item,checker);
-        }
+		[Obsolete]
+		public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon,
+						Action<CreatureGuid, string, MapMenuItem> callback, bool closeMenu)
+		{
+			CreateSubMenuItem(mainGuid, title, icon, callback, closeMenu, null);
+		}
 
-        /// <summary>
-        /// Method for loading icons (sprites) from a file.
-        /// </summary>
-        /// <param name="fileName">Drive, path and file name of the PNG or JPG file</param>
-        /// <returns>Spite holding the icon (which can be passed into the menu creation methods)</returns>
-        public static Sprite GetIconFromFile(string fileName)
-        {
-            Texture2D tex = new Texture2D(32, 32);
-            try
-            {
-                
-                tex.LoadImage(System.IO.File.ReadAllBytes(fileName));
-            }
-            catch (Exception e)
-            {
-                Debug.Log($"Error thrown getting file: {e}");
-                return null;
-            } 
-            return Sprite.Create(tex, new Rect(0, 0, 32, 32), new Vector2(0.5f, 0.5f));
-        }
+		[Obsolete]
+		public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, 
+				Action<CreatureGuid, string, MapMenuItem> callback)
+		{
+			CreateSubMenuItem(mainGuid, title, icon, callback, true, null);
+		}
 
-        /// <summary>
-        /// mMethid used internally for tracking which mini the radial menu was opened on
-        /// </summary>
-        /// <param name="selected">Selected mini</param>
-        /// <param name="radial">Radial menu mini</param>
-        /// <returns></returns>
-        private static bool Reporter(NGuid selected, NGuid radial)
-        {
-            radialAsset = new CreatureGuid(radial);
-            return true;
-        }
+		/// <summary>
+		/// Add sub-menu items to a main menu entry
+		/// </summary>
+		/// <param name="mainGuid">Guid of the main menu entry</param>
+		/// <param name="title">Text associated with the sub-menu item</param>
+		/// <param name="icon">Icon associated with the sub-menu item</param>
+		/// <param name="callback">Callback that is called when the sub-menu item is selected</param>
+		/// <param name="closeMenu">Determines if the menu is closed after sub-menu item is selected</param>
+		/// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
+		public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<CreatureGuid, string, MapMenuItem> callback, bool closeMenu = true, Func<bool> checker = null)
+		{
+			// Check if the main menu Guid exists
+			if (!subMenuEntries.ContainsKey(mainGuid))
+			{
+				Debug.LogWarning($"Main radial menu '{mainGuid}' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
+				return;
+			}
+			// Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
+			var item = new MapMenu.ItemArgs
+			{
+				// Parent plugin specified callback for when the sub-menu item is selected
+				Action = (mmi, obj) => { callback(radialAsset, mainGuid, mmi); },
+				Icon = icon,
+				Title = title,
+				CloseMenuOnActivate = closeMenu
+			};
+			subMenuEntries[mainGuid].Add(item);
+			if (checker != null) subMenuChecker.Add(item, checker);
+		}
 
-        /// <summary>
-        /// mMethid used internally for tracking which mini the radial menu was opened on
-        /// </summary>
-        /// <param name="item">Radial menu for Hide Volume</param>
-        /// <returns></returns>
-        private static bool Reporter(HideVolumeItem item)
-        {
-            radialHideVolume = item;
-            return true;
-        }
+		/// <summary>
+		/// Add sub-menu items to a maim menu entry
+		/// </summary>
+		/// <param name="mainGuid">Guid of the main menu entry</param>
+		/// <param name="title">Text associated with the sub-menu item</param>
+		/// <param name="icon">Icon associated with the sub-menu item</param>
+		/// <param name="callback">Callback that is called when the sub-menu item is selected</param>
+		/// <param name="closeMenu">Determines if the menu is closed after sub-menu item is selected</param>
+		/// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
+		public static void CreateSubMenuItem(string mainGuid, string title, Sprite icon, Action<HideVolumeItem, string, MapMenuItem> callback, bool closeMenu = true, Func<bool> checker = null)
+		{
+			// Check if the main menu Guid exists
+			if (!subMenuEntries.ContainsKey(mainGuid))
+			{
+				Debug.LogWarning("Main radial menu '" + mainGuid + "' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
+				return;
+			}
+			// Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
+			var item = new MapMenu.ItemArgs
+			{
+				// Parent plugin specified callback for when the sub-menu item is selected
+				Action = (mmi, obj) => { callback(radialHideVolume, mainGuid, mmi); },
+				Icon = icon,
+				Title = title,
+				CloseMenuOnActivate = closeMenu
+			};
+			subMenuEntries[mainGuid].Add(item);
+			if (checker != null) subMenuChecker.Add(item, checker);
+		}
 
-        /// <summary>
-        /// Method called by the main menu to generate the corresponding sub-menu
-        /// </summary>
-        /// <param name="mmi">MapMenuItem associated with the main menu</param>
-        /// <param name="obj">Object associated with the main menu</param>
-        /// <param name="mainGuid">Guid of the main menu</param>
-        private static void DisplaySubmenu(MapMenuItem mmi, object obj, string mainGuid)
-        {
-            Vector3 result;
-            if (openMenuType == MenuType.character)
-                result = GetRadialTargetCreature().transform.position + Vector3.up * GetHeightDiff();
-            else result = GetRadialTargetHideVolume();
+		/// <summary>
+		/// Add sub-menu items to a maim menu entry
+		/// </summary>
+		/// <param name="mainGuid">Guid of the main menu entry</param>
+		/// <param name="item">Uses standard mapmenu item args for greater flexibility</param>
+		/// <param name="callback">Callback that is called when the sub-menu item is selected if you want 3 parameter return</param>
+		/// <param name="checker">Optional checker used to determine whether to add button for submenu</param>
+		public static void CreateSubMenuItem(string mainGuid, MapMenu.ItemArgs item, Action<HideVolumeItem, string, MapMenuItem> callback = null, Func<bool> checker = null)
+		{
+			// Check if the main menu Guid exists
+			if (!subMenuEntries.ContainsKey(mainGuid))
+			{
+				Debug.LogWarning("Main radial menu '" + mainGuid + "' does not exits. Use EnsureMainMenuItem() before adding sub-menu items.");
+				return;
+			}
 
-            // Create sub-menu
-            MapMenu mapMenu = MapMenuManager.OpenMenu(result,true);
-            // Populate sub-menu based on all items added by any plugins for the specific main menu entry
-            foreach (MapMenu.ItemArgs item in subMenuEntries[mainGuid])
-            {
-                if (!subMenuChecker.ContainsKey(item) || subMenuChecker[item]()) mapMenu.AddItem(item);
-            }
-        }
+			if (callback != null) item.Action = (mmi, obj) => { callback(radialHideVolume, mainGuid, mmi); };
 
-        /// Get Pos for Creature
-        private static Creature GetRadialTargetCreature()
-        {
-            var x = (CreatureMenuBoardTool)GameObject.FindObjectOfType(typeof(CreatureMenuBoardTool));
+			// Add the item to the sub-menu item dictionary for the main menu entry (indicated by the Guid)
+			subMenuEntries[mainGuid].Add(item);
+			if (checker != null) subMenuChecker.Add(item, checker);
+		}
 
-            FieldInfo mapField = x.GetType().GetField("_selectedCreature", bindFlags);
-            return (Creature)mapField.GetValue(x);
-        }
-        private static float GetHeightDiff()
-        {
-            var x = (CreatureMenuBoardTool)GameObject.FindObjectOfType(typeof(CreatureMenuBoardTool));
-            FieldInfo mapField = x.GetType().GetField("_hitHeightDif", bindFlags);
-            return (float)mapField.GetValue(x);
-        }
+		/// <summary>
+		/// Method for loading icons (sprites) from a file.
+		/// </summary>
+		/// <param name="fileName">Drive, path and file name of the PNG or JPG file</param>
+		/// <returns>Spite holding the icon (which can be passed into the menu creation methods)</returns>
+		public static Sprite GetIconFromFile(string fileName)
+		{
+			Texture2D tex = new Texture2D(32, 32);
+			try
+			{
 
-        // Get Pos for Hide Volume
-        private static Vector3 GetRadialTargetHideVolume()
-        {
-            var x = (GMHideVolumeMenuBoardTool)GameObject.FindObjectOfType(typeof(GMHideVolumeMenuBoardTool));
-            FieldInfo mapField = x.GetType().GetField("_selectedPos", bindFlags);
-            return (Vector3)mapField.GetValue(x);
-        }
+				tex.LoadImage(System.IO.File.ReadAllBytes(fileName));
+			}
+			catch (Exception e)
+			{
+				Debug.Log($"Error thrown getting file: {e}");
+				return null;
+			}
+			return Sprite.Create(tex, new Rect(0, 0, 32, 32), new Vector2(0.5f, 0.5f));
+		}
 
-        private const BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+		/// <summary>
+		/// Method used internally for tracking which mini the radial menu was opened on
+		/// </summary>
+		/// <param name="selected">Selected mini</param>
+		/// <param name="radial">Radial menu mini</param>
+		/// <returns></returns>
+		private static bool Reporter(NGuid selected, NGuid radial)
+		{
+			radialAsset = new CreatureGuid(radial);
+			return true;
+		}
 
-    }
+		/// <summary>
+		/// Method used internally for tracking which mini the radial menu was opened on
+		/// </summary>
+		/// <param name="item">Radial menu for Hide Volume</param>
+		/// <returns></returns>
+		private static bool Reporter(HideVolumeItem item)
+		{
+			radialHideVolume = item;
+			return true;
+		}
+
+		/// <summary>
+		/// Method called by the main menu to generate the corresponding sub-menu
+		/// </summary>
+		/// <param name="mmi">MapMenuItem associated with the main menu</param>
+		/// <param name="obj">Object associated with the main menu</param>
+		/// <param name="mainGuid">Guid of the main menu</param>
+		private static void DisplaySubmenu(MapMenuItem mmi, object obj, string mainGuid)
+		{
+			Vector3 result;
+			if (openMenuType == MenuType.character)
+				result = Talespire.RadialMenus.GetTargetCreature().transform.position + Vector3.up * Talespire.RadialMenus.GetHeightDiff();
+			else 
+				result = Talespire.RadialMenus.GetRadialTargetHideVolume();
+
+			// Create sub-menu
+			MapMenu mapMenu = MapMenuManager.OpenMenu(result, true);
+
+			// Populate sub-menu based on all items added by any plugins for the specific main menu entry
+			foreach (MapMenu.ItemArgs item in subMenuEntries[mainGuid])
+				if (!subMenuChecker.ContainsKey(item) || subMenuChecker[item]())
+					mapMenu.AddItem(item);
+		}
+	}
 }

--- a/RadialUIPlugin/RadialUIPlugin.cs
+++ b/RadialUIPlugin/RadialUIPlugin.cs
@@ -5,375 +5,349 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
+using TaleSpireCore;
 using Object = System.Object;
 
 namespace RadialUI
 {
 
-    [BepInPlugin(Guid, "RadialUIPlugin", Version)]
-    public class RadialUIPlugin : BaseUnityPlugin
-    {
-        // constants
-        public const string Guid = "org.hollofox.plugins.RadialUIPlugin";
-        public const string Version = "1.5.1.0";
+	[BepInPlugin(Guid, "RadialUIPlugin", Version)]
+	public class RadialUIPlugin : BaseUnityPlugin
+	{
+		// constants
+		public const string Guid = "org.hollofox.plugins.RadialUIPlugin";
+		public const string Version = "1.5.0.0";
 
-        /// <summary>
-        /// Awake plugin
-        /// </summary>
-        void Awake()
-        {
-            Logger.LogInfo("In Awake for RadialUI");
+		/// <summary>
+		/// Awake plugin
+		/// </summary>
+		void Awake()
+		{
+			Logger.LogInfo("In Awake for RadialUI");
 
-            Debug.Log("RadialUI Plug-in loaded");
-        }
-
-
-        // Character Related Add
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid,NGuid, bool>)> _onCharacterCallback = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onCanAttack = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onCantAttack = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuEmotes = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuKill = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuGm = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuAttacks = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuSize = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
-
-        // Character Related Remove
-        private static readonly Dictionary<string, List<string>> _removeOnCharacter = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnCanAttack = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnCantAttack = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnSubmenuEmotes = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnSubmenuKill = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnSubmenuGm = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnSubmenuAttacks = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnSubmenuSize = new Dictionary<string, List<string>>();
-        private static readonly Dictionary<string, List<string>> _removeOnHideVolume = new Dictionary<string, List<string>>();
-
-        // Hide Volumes
-        private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem,bool>)> _onHideVolumeCallback = new Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem,bool>)>();
-
-        // Add On Character
-        public static void AddOnCharacter(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCharacterCallback.Add(key,(value, externalCheck));
-        public static void AddOnCanAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCanAttack.Add(key,(value, externalCheck));
-        public static void AddOnCantAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCantAttack.Add(key,(value, externalCheck));
-        public static void AddOnSubmenuEmotes(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuEmotes.Add(key,(value, externalCheck));
-        public static void AddOnSubmenuKill(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuKill.Add(key,(value, externalCheck));
-        public static void AddOnSubmenuGm(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuGm.Add(key,(value, externalCheck));
-        public static void AddOnSubmenuAttacks(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuAttacks.Add(key,(value, externalCheck));
-        public static void AddOnSubmenuSize(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuSize.Add(key,(value, externalCheck));
-
-        // Add On HideVolume
-        public static void AddOnHideVolume(string key, MapMenu.ItemArgs value, Func<HideVolumeItem,bool> externalCheck = null) => _onHideVolumeCallback.Add(key, (value, externalCheck));
-
-        // Remove On Character
-        public static bool RemoveOnCharacter(string key) => _onCharacterCallback.Remove(key);
-        public static bool RemoveOnCanAttack(string key) => _onCanAttack.Remove(key);
-        public static bool RemoveOnCantAttack(string key) => _onCantAttack.Remove(key);
-        public static bool RemoveOnSubmenuEmotes(string key) => _onSubmenuEmotes.Remove(key);
-        public static bool RemoveOnSubmenuKill(string key) => _onSubmenuKill.Remove(key);
-        public static bool RemoveOnSubmenuGm(string key) => _onSubmenuGm.Remove(key);
-        public static bool RemoveOnSubmenuAttacks(string key) => _onSubmenuAttacks.Remove(key);
-        public static bool RemoveOnSubmenuSize(string key) => _onSubmenuSize.Remove(key);
-
-        // Add RemoveOn
-        public static void AddOnRemoveSubmenuAttacks(string key, string value) => AddRemoveOn(_removeOnSubmenuAttacks,key,value);
-        public static void AddOnRemoveCanAttack(string key, string value) => AddRemoveOn(_removeOnCanAttack,key,value);
-        public static void AddOnRemoveCantAttack(string key, string value) => AddRemoveOn(_removeOnCantAttack,key,value);
-        public static void AddOnRemoveCharacter(string key, string value) => AddRemoveOn(_removeOnCharacter,key,value);
-        public static void AddOnRemoveHideVolume(string key, string value) => AddRemoveOn(_removeOnHideVolume,key,value);
-        public static void AddOnRemoveSubmenuEmotes(string key, string value) => AddRemoveOn(_removeOnSubmenuEmotes,key,value);
-        public static void AddOnRemoveSubmenuGm(string key, string value) => AddRemoveOn(_removeOnSubmenuGm,key,value);
-        public static void AddOnRemoveSubmenuKill(string key, string value) => AddRemoveOn(_removeOnSubmenuKill,key,value);
-        public static void AddOnRemoveSubmenuSize(string key, string value) => AddRemoveOn(_removeOnSubmenuSize,key,value);
-
-        // Remove RemoveOn
-        public static void RemoveOnRemoveSubmenuAttacks(string key, string value) => RemoveRemoveOn(_removeOnSubmenuAttacks, key, value);
-        public static void RemoveOnRemoveCanAttack(string key, string value) => RemoveRemoveOn(_removeOnCanAttack, key, value);
-        public static void RemoveOnRemoveCantAttack(string key, string value) => RemoveRemoveOn(_removeOnCantAttack, key, value);
-        public static void RemoveOnRemoveCharacter(string key, string value) => RemoveRemoveOn(_removeOnCharacter, key, value);
-        public static void RemoveOnRemoveHideVolume(string key, string value) => RemoveRemoveOn(_removeOnHideVolume, key, value);
-        public static void RemoveOnRemoveSubmenuEmotes(string key, string value) => RemoveRemoveOn(_removeOnSubmenuEmotes, key, value);
-        public static void RemoveOnRemoveSubmenuGm(string key, string value) => RemoveRemoveOn(_removeOnSubmenuGm, key, value);
-        public static void RemoveOnRemoveSubmenuKill(string key, string value) => RemoveRemoveOn(_removeOnSubmenuKill, key, value);
-        public static void RemoveOnRemoveSubmenuSize(string key, string value) => RemoveRemoveOn(_removeOnSubmenuSize, key, value);
-
-        private static void AddRemoveOn(Dictionary<string, List<string>> data, string key, string value)
-        {
-            if (!data.ContainsKey(key)) data.Add(key, new List<string>());
-            data[key].Add(value);
-        }
-
-        private static bool RemoveRemoveOn(Dictionary<string, List<string>> data, string key, string value)
-        {
-            return data.ContainsKey(key) && data[key].Remove(value);
-        }
-
-        // Remove On HideVolume
-        public static bool RemoveOnHideVolume(string key) => _onHideVolumeCallback.Remove(key);
-
-        // Check to see if map menu is new
-        private static int last = 0;
-        private static string lastTitle = "";
-        private static bool lastSuccess = true;
-        private static DateTime Execute;
-
-        // Last Creature/HideVolume
-        private static NGuid target;
-        private static HideVolumeItem lastHideVolumeItem;
-
-        private (Action<MapMenuItem, Object>, MapMenuItem, Object) pending = (null,null,null);
-
-        /// <summary>
-        /// Looping method run by plugin
-        /// </summary>
-        void Update()
-        {
-            if (MapMenuManager.HasInstance && MapMenuManager.IsOpen)
-            {
-
-                var instance = MapMenuManager.Instance;
-                var type = instance.GetType();
-
-                var field = type.GetField("_allOpenMenus", bindFlags);
-                var menus = (List<MapMenu>)field.GetValue(instance);
-
-                if (menus.Count >= 1 && menus.Count >= last)
-                {
-                    try
-                    {
-                        var map = menus[menus.Count - 1];
-                        var Map = map.transform.GetChild(0).GetChild(0);
-                        var mapComponent = Map.GetComponent<MapMenuItem>();
-                        var mapField = mapComponent.GetType().GetField("_title", bindFlags);
-                        var title = (string) mapField.GetValue(mapComponent);
-                        if (menus.Count == last && lastTitle != title) last -= 1;
-                        Probe();
-                        lastTitle = title;
-                        lastSuccess = true;
-                    }
-                    catch (Exception e)
-                    {
-                        // Probably Stat open
-                        if (lastSuccess == true)
-                        {
-                            Debug.Log($"Error: {e}, most likely stat submenu being opened");
-                            lastSuccess = false;
-                        }
-                    }
-                }
-                last = menus.Count;
-            }
-            else
-            {
-                last = 0;
-                lastTitle = "";
-                lastSuccess = true;
-            }
-
-            if (pending.Item1 != null && Execute != DateTime.MinValue && DateTime.Now > Execute)
-            {
-                pending.Item1(pending.Item2, pending.Item3);
-                pending = (null, null, null);
-                Execute = DateTime.MinValue;
-            }
-        }
-
-        private const BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
-
-        private void Probe()
-        { 
-            var instance = MapMenuManager.Instance;
-            var type = instance.GetType();
-            
-            var field = type.GetField("_allOpenMenus", bindFlags);
-            var menus = (List<MapMenu>) field.GetValue(instance);
-
-            for(var i = last; i < menus.Count; i++)
-            {
-                var map = menus[i];
-                var Map = map.transform.GetChild(0).GetChild(0);
-                var mapComponent = Map.GetComponent<MapMenuItem>();
-
-                var mapField = mapComponent.GetType().GetField("_title", bindFlags);
-                var title = (string)mapField.GetValue(mapComponent);
-
-                var id = LocalClient.SelectedCreatureId.Value;
-
-                Debug.Log(title);
-
-                // Minis Related
-                Record(map);
-
-                if (IsMini(title)) RemoveRadialComponent(_removeOnCharacter, map);
-                if (CanAttack(title)) RemoveRadialComponent(_removeOnCanAttack, map);
-                if (CanNotAttack(title)) RemoveRadialComponent(_removeOnCantAttack, map);
-
-                if (IsMini(title)) AddCreatureEvent(_onCharacterCallback,id,map);
-                if (CanAttack(title)) AddCreatureEvent(_onCanAttack, id, map);
-                if (CanNotAttack(title)) AddCreatureEvent(_onCantAttack, id, map);
-                
-                // Minis Submenu
-                
-
-                if (IsEmotes(title)) RemoveRadialComponent(_removeOnSubmenuEmotes, map);
-                if (IsKill(title)) RemoveRadialComponent(_removeOnSubmenuKill, map);
-                if (IsGmMenu(title)) RemoveRadialComponent(_removeOnSubmenuGm, map);
-                if (IsAttacksMenu(title)) RemoveRadialComponent(_removeOnSubmenuAttacks, map);
-                if (IsSizeMenu(title)) RemoveRadialComponent(_removeOnSubmenuSize, map);
-
-                if (IsEmotes(title)) AddCreatureEvent(_onSubmenuEmotes, id, map);
-                if (IsKill(title)) AddCreatureEvent(_onSubmenuKill, id, map);
-                if (IsGmMenu(title)) AddCreatureEvent(_onSubmenuGm, id, map);
-                if (IsAttacksMenu(title)) AddCreatureEvent(_onSubmenuAttacks, id, map);
-                if (IsSizeMenu(title)) AddCreatureEvent(_onSubmenuSize, id, map);
+			Debug.Log("RadialUI Plug-in loaded");
+		}
 
 
-                // Hide Volumes
-                if (IsHideVolume(title)) RemoveRadialComponent(_removeOnHideVolume, map);
-                if (IsHideVolume(title)) AddHideVolumeEvent(_onHideVolumeCallback, map);
-            }
-        }
+		// Character Related Add
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onCharacterCallback = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onCanAttack = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onCantAttack = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuEmotes = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuKill = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuGm = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuAttacks = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> _onSubmenuSize = new Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)>();
 
-        private static void RemoveRadialComponent(Dictionary<string, List<string>> removeOnCharacter, MapMenu map)
-        {
-            var indexes = removeOnCharacter.SelectMany(i => i.Value).Distinct();
-            foreach (var index in indexes) Debug.Log($"Index:{index}");
-            foreach (var index in indexes.Where(i => foundTitles.Contains(i)))
-            {
-                var Map = map.transform.GetChild(0);
-                for (var i = 0; i < Map.childCount; i++)
-                {
-                    try
-                    {
-                        var mapComponent = Map.GetChild(i).GetComponent<MapMenuItem>();
-                        var mapField = mapComponent.GetType().GetField("_title", bindFlags);
-                        var title = (string) mapField.GetValue(mapComponent);
-                        if (title != index) continue;
-                        Debug.Log($"found: {index}");
-                        Map.GetChild(i).gameObject.SetActive(false);
-                        i = Map.childCount;
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.Log(e);
-                    }
-                }
-            }
-        }
+		// Character Related Remove
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnCharacter = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnCanAttack = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnCantAttack = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnSubmenuEmotes = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnSubmenuKill = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnSubmenuGm = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnSubmenuAttacks = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnSubmenuSize = new Dictionary<string, List<RadialCheckRemove>>();
+		private static readonly Dictionary<string, List<RadialCheckRemove>> _removeOnHideVolume = new Dictionary<string, List<RadialCheckRemove>>();
 
-        private static List<string> foundTitles = new List<string>();
+		// Hide Volumes
+		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)> _onHideVolumeCallback = new Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)>();
 
-        private static void Record(MapMenu map)
-        {
-            foundTitles = new List<string>();
-            var Map = map.transform.GetChild(0);
-            for (var i = 0; i < Map.childCount; i++)
-            {
-                try
-                {
-                    var mapComponent = Map.GetChild(i).GetComponent<MapMenuItem>();
-                    var mapField = mapComponent.GetType().GetField("_title", bindFlags);
-                    var title = (string) mapField.GetValue(mapComponent);
-                    foundTitles.Add(title);
-                }
-                catch (Exception e)
-                {
-                    Debug.Log(e);
-                }
-            }
-        }
+		// Add On Character
+		public static void AddOnCharacter(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCharacterCallback.Add(key, (value, externalCheck));
+		public static void AddOnCanAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCanAttack.Add(key, (value, externalCheck));
+		public static void AddOnCantAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCantAttack.Add(key, (value, externalCheck));
+		public static void AddOnSubmenuEmotes(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuEmotes.Add(key, (value, externalCheck));
+		public static void AddOnSubmenuKill(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuKill.Add(key, (value, externalCheck));
+		public static void AddOnSubmenuGm(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuGm.Add(key, (value, externalCheck));
+		public static void AddOnSubmenuAttacks(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuAttacks.Add(key, (value, externalCheck));
+		public static void AddOnSubmenuSize(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuSize.Add(key, (value, externalCheck));
 
-        private void AddCreatureEvent(Dictionary<string, (MapMenu.ItemArgs, Func<NGuid, NGuid, bool>)> dic, NGuid myCreature, MapMenu map)
-        {
-            target = GetRadialTargetCreature();
-            foreach (var handlers
-                in dic.Values
-                    .Where(handlers => handlers.Item2 == null
-                                       || handlers.Item2(myCreature, target))){
-                    map.AddItem(
-                        new MapMenu.ItemArgs
-                        {
-                            Title = handlers.Item1.Title,
-                            Icon = handlers.Item1.Icon,
-                            Action = (mmi, obj) =>
-                            {
-                                
+		// Add On HideVolume
+		public static void AddOnHideVolume(string key, MapMenu.ItemArgs value, Func<HideVolumeItem, bool> externalCheck = null) => _onHideVolumeCallback.Add(key, (value, externalCheck));
 
-                                pending = (handlers.Item1.Action,mmi,obj);
-                                Execute = DateTime.Now.AddMilliseconds(200);
-                            },
-                            CloseMenuOnActivate = handlers.Item1.CloseMenuOnActivate,
-                            ValueText = handlers.Item1.ValueText,
-                            SubValueText = handlers.Item1.SubValueText,
-                            FadeName = handlers.Item1.FadeName,
-                            Obj = handlers.Item1.Obj,
-                        }
-                    );
-                    var count = map.transform.childCount;
-                    var last = map.transform.GetChild(count - 1);
-                    var rectTrans = last.transform.GetChild(0).GetChild(0).GetComponent<RectTransform>();
-                    rectTrans.sizeDelta = new Vector2(48f, 48f);
-                    Debug.Log("Set Size 48");
-            }
-        }
+		// Remove On Character
+		public static bool RemoveOnCharacter(string key) => _onCharacterCallback.Remove(key);
+		public static bool RemoveOnCanAttack(string key) => _onCanAttack.Remove(key);
+		public static bool RemoveOnCantAttack(string key) => _onCantAttack.Remove(key);
+		public static bool RemoveOnSubmenuEmotes(string key) => _onSubmenuEmotes.Remove(key);
+		public static bool RemoveOnSubmenuKill(string key) => _onSubmenuKill.Remove(key);
+		public static bool RemoveOnSubmenuGm(string key) => _onSubmenuGm.Remove(key);
+		public static bool RemoveOnSubmenuAttacks(string key) => _onSubmenuAttacks.Remove(key);
+		public static bool RemoveOnSubmenuSize(string key) => _onSubmenuSize.Remove(key);
 
-        private static NGuid GetRadialTargetCreature()
-        {
-            var x = (CreatureMenuBoardTool)GameObject.FindObjectOfType(typeof(CreatureMenuBoardTool));
+		
+		// Add RemoveOn
+		public static void AddOnRemoveSubmenuAttacks(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuAttacks, key, value, callback);
+		public static void AddOnRemoveCanAttack(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCanAttack, key, value, callback);
+		public static void AddOnRemoveCantAttack(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCantAttack, key, value, callback);
+		public static void AddOnRemoveCharacter(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCharacter, key, value, callback);
+		public static void AddOnRemoveHideVolume(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnHideVolume, key, value, callback);
+		public static void AddOnRemoveSubmenuEmotes(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuEmotes, key, value, callback);
+		public static void AddOnRemoveSubmenuGm(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuGm, key, value, callback);
+		public static void AddOnRemoveSubmenuKill(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuKill, key, value, callback);
+		public static void AddOnRemoveSubmenuSize(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuSize, key, value, callback);
 
-            FieldInfo mapField = x.GetType().GetField("_selectedCreature", bindFlags);
-            var selectedCreature = (Creature)mapField.GetValue(x);
-            return selectedCreature.CreatureId.Value;
-        }
+		// Remove RemoveOn
+		public static void RemoveOnRemoveSubmenuAttacks(string key, string value) => RemoveRemoveOn(_removeOnSubmenuAttacks, key, value);
+		public static void RemoveOnRemoveCanAttack(string key, string value) => RemoveRemoveOn(_removeOnCanAttack, key, value);
+		public static void RemoveOnRemoveCantAttack(string key, string value) => RemoveRemoveOn(_removeOnCantAttack, key, value);
+		public static void RemoveOnRemoveCharacter(string key, string value) => RemoveRemoveOn(_removeOnCharacter, key, value);
+		public static void RemoveOnRemoveHideVolume(string key, string value) => RemoveRemoveOn(_removeOnHideVolume, key, value);
+		public static void RemoveOnRemoveSubmenuEmotes(string key, string value) => RemoveRemoveOn(_removeOnSubmenuEmotes, key, value);
+		public static void RemoveOnRemoveSubmenuGm(string key, string value) => RemoveRemoveOn(_removeOnSubmenuGm, key, value);
+		public static void RemoveOnRemoveSubmenuKill(string key, string value) => RemoveRemoveOn(_removeOnSubmenuKill, key, value);
+		public static void RemoveOnRemoveSubmenuSize(string key, string value) => RemoveRemoveOn(_removeOnSubmenuSize, key, value);
 
-        /// <summary>
-        /// Fetches the last creature the menu has been open on (menu open or closed)
-        /// </summary>
-        /// <returns>NGuid for the last creature that the Radial Menu has been opened on.</returns>
-        public static NGuid GetLastRadialTargetCreature()
-        {
-            return target;
-        }
+		private static void AddRemoveOn(Dictionary<string, List<RadialCheckRemove>> data, string key, string value, ShouldShowMenu shouldRemoveCallback)
+		{
+			if (!data.ContainsKey(key))
+				data.Add(key, new List<RadialCheckRemove>());
+			data[key].Add(new RadialCheckRemove(value, shouldRemoveCallback));
+		}
 
-        /// <summary>
-        /// Fetches the last creature the menu has been open on (menu open or closed)
-        /// </summary>
-        /// <returns>NGuid for the last creature that the Radial Menu has been opened on.</returns>
-        public static HideVolumeItem GetLastRadialHideVolume()
-        {
-            return lastHideVolumeItem;
-        }
+		private static bool RemoveRemoveOn(Dictionary<string, List<RadialCheckRemove>> data, string key, string value)
+		{
+			if (!data.ContainsKey(key))
+				return false;
+			List<RadialCheckRemove> radialCheckRemoves = data[key];
+			int countBefore = radialCheckRemoves.Count;
+			radialCheckRemoves.RemoveAll(x => x.TitleToRemove == value);
+			bool successfullyRemoved = radialCheckRemoves.Count != countBefore;
+			if (radialCheckRemoves.Count == 0)
+				data.Remove(key);
+			return successfullyRemoved;
+		}
 
-        private void AddHideVolumeEvent(Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)> dic, MapMenu map)
-        {
-            lastHideVolumeItem = GetSelectedHideVolumeItem();
-            foreach (var handlers
-                in dic.Values
-                    .Where(handlers => handlers.Item2 == null
-                                       || handlers.Item2(lastHideVolumeItem))) map.AddItem(handlers.Item1);
-        }
+		// Remove On HideVolume
+		public static bool RemoveOnHideVolume(string key) => _onHideVolumeCallback.Remove(key);
 
-        private static HideVolumeItem GetSelectedHideVolumeItem()
-        {
-            var tool = (GMHideVolumeMenuBoardTool)GameObject.FindObjectOfType(typeof(GMHideVolumeMenuBoardTool));
-            FieldInfo mapField = tool.GetType().GetField("_selectedVolume", bindFlags);
-            return (HideVolumeItem) mapField.GetValue(tool);
-        }
+		// Check to see if map menu is new
+		private static int lastMenuCount = 0;
+		private static string lastTitle = "";
+		private static bool lastSuccess = true;
+		private static DateTime menuExecutionTime;
+
+		// Last Creature/HideVolume
+		private static NGuid target;
+		private static HideVolumeItem lastHideVolumeItem;
+
+		private (Action<MapMenuItem, Object>, MapMenuItem, Object) pendingMenuAction = (null, null, null);
+
+		/// <summary>
+		/// Looping method run by plugin
+		/// </summary>
+		void Update()
+		{
+			ExecutePendingMenuActionIfNecessary();
+
+			if (!MapMenuManager.HasInstance || !MapMenuManager.IsOpen)
+			{
+				if (needToClear)
+				{
+					needToClear = false;
+					lastMenuCount = 0;
+					lastTitle = "";
+					lastSuccess = true;
+					ClearPreviouslyModded();
+				}
+				return;
+			}
+
+			needToClear = true;
+			List<MapMenu> menus = Talespire.RadialMenus.GetAllOpen();
+
+			if (menus.Count >= 1 && menus.Count >= lastMenuCount)
+			{
+				try
+				{
+					string title = menus[menus.Count - 1].GetTitle();
+
+					if (menus.Count == lastMenuCount && lastTitle != title)
+						lastMenuCount -= 1;
+
+					ModifyMenus();
+					lastTitle = title;
+					lastSuccess = true;
+				}
+				catch (Exception e)
+				{
+					// Probably Stat open
+					if (lastSuccess)
+					{
+						Debug.Log($"Error: {e}, most likely stat submenu being opened");
+						lastSuccess = false;
+					}
+				}
+			}
+			lastMenuCount = menus.Count;
+		}
+
+		private void ExecutePendingMenuActionIfNecessary()
+		{
+			if (pendingMenuAction.Item1 == null || menuExecutionTime == DateTime.MinValue || DateTime.Now <= menuExecutionTime)
+				return;
+
+			pendingMenuAction.Item1(pendingMenuAction.Item2, pendingMenuAction.Item3);
+			pendingMenuAction = (null, null, null);
+			menuExecutionTime = DateTime.MinValue;
+		}
+
+		private void ModifyMenus()
+		{
+			List<MapMenu> menus = Talespire.RadialMenus.GetAllOpen();
+
+			NGuid selectedCreatureId = LocalClient.SelectedCreatureId.Value;
+
+			for (var i = lastMenuCount; i < menus.Count; i++)
+			{
+				MapMenu mapMenu = menus[i];
+				string title = mapMenu.GetTitle();
+				Debug.Log(title);
+
+				// Minis Related
+				if (IsMini(title)) AddMenuItem(_onCharacterCallback, selectedCreatureId, mapMenu);
+				if (CanAttack(title)) AddMenuItem(_onCanAttack, selectedCreatureId, mapMenu);
+				if (CanNotAttack(title)) AddMenuItem(_onCantAttack, selectedCreatureId, mapMenu);
+
+				if (IsMini(title)) RemoveMenuItem(_removeOnCharacter, selectedCreatureId, mapMenu);
+				if (CanAttack(title)) RemoveMenuItem(_removeOnCanAttack, selectedCreatureId, mapMenu);
+				if (CanNotAttack(title)) RemoveMenuItem(_removeOnCantAttack, selectedCreatureId, mapMenu);
+
+				// Minis Submenu
+				if (IsEmotes(title)) AddMenuItem(_onSubmenuEmotes, selectedCreatureId, mapMenu);
+				if (IsKill(title)) AddMenuItem(_onSubmenuKill, selectedCreatureId, mapMenu);
+				if (IsGmMenu(title)) AddMenuItem(_onSubmenuGm, selectedCreatureId, mapMenu);
+				if (IsAttacksMenu(title)) AddMenuItem(_onSubmenuAttacks, selectedCreatureId, mapMenu);
+				if (IsSizeMenu(title)) AddMenuItem(_onSubmenuSize, selectedCreatureId, mapMenu);
+
+				if (IsEmotes(title)) RemoveMenuItem(_removeOnSubmenuEmotes, selectedCreatureId, mapMenu);
+				if (IsKill(title)) RemoveMenuItem(_removeOnSubmenuKill, selectedCreatureId, mapMenu);
+				if (IsGmMenu(title)) RemoveMenuItem(_removeOnSubmenuGm, selectedCreatureId, mapMenu);
+				if (IsAttacksMenu(title)) RemoveMenuItem(_removeOnSubmenuAttacks, selectedCreatureId, mapMenu);
+				if (IsSizeMenu(title)) RemoveMenuItem(_removeOnSubmenuSize, selectedCreatureId, mapMenu);
+
+				// Hide Volumes
+				if (IsHideVolume(title)) RemoveMenuItem(_removeOnHideVolume, selectedCreatureId, mapMenu);
+				if (IsHideVolume(title)) AddHideVolumeEvent(_onHideVolumeCallback, mapMenu);
+			}
+		}
+
+		private static void RemoveMenuItem(Dictionary<string, List<RadialCheckRemove>> removeOnCharacter, NGuid miniAtMenu, MapMenu map)
+		{
+			target = Talespire.RadialMenus.GetTargetCreatureId();
+			IEnumerable<string> indexes = removeOnCharacter.SelectMany(i => i.Value.Select(x => x.TitleToRemove)).Distinct();
+			Debug.Log("We expect to be removing these titles (perhaps conditionally):");
+			foreach (string index in indexes)
+				Debug.Log("  " + index);
+
+			Transform Map = map.transform.GetChild(0);
+			for (int i = 0; i < Map.childCount; i++)
+			{
+				Transform transform = Map.GetChild(i);
+				MapMenuItem mapMenuItem = transform.GetComponent<MapMenuItem>();
+				string menuTitle = mapMenuItem.GetTitle();
+				Debug.Log($"Map.GetChild({i}) = \"{menuTitle}\"");
+
+				foreach (string key in removeOnCharacter.Keys)
+					foreach (RadialCheckRemove radialCheckRemove in removeOnCharacter[key])
+						if (radialCheckRemove.TitleToRemove == menuTitle &&
+							(radialCheckRemove.ShouldRemoveCallback == null || radialCheckRemove.ShouldRemoveCallback(menuTitle, miniAtMenu.ToString(), target.ToString())))
+						{
+							Debug.Log($"RemoveRadialComponent - : {menuTitle}");
+							transform.gameObject.SetActive(false);
+							return;
+						}
+			}
+		}
+
+		List<MapMenu.ItemArgs> previouslyModded = new List<MapMenu.ItemArgs>();
+		bool needToClear;
+
+		public void ClearPreviouslyModded()
+		{
+			previouslyModded.Clear();
+		}
+
+		private void AddMenuItem(Dictionary<string, (MapMenu.ItemArgs mapArgs, Func<NGuid, NGuid, bool> shouldAdd)> dic, NGuid myCreature, MapMenu mapMenu)
+		{
+			target = Talespire.RadialMenus.GetTargetCreatureId();
+
+			var validMenuMods = new List<(MapMenu.ItemArgs mapArgs, Func<NGuid, NGuid, bool> shouldAdd)>();
+			foreach (string key in dic.Keys)
+			{
+				var menuMod = dic[key];
+				if (menuMod.shouldAdd == null || menuMod.shouldAdd(myCreature, target))
+					if (!previouslyModded.Contains(menuMod.mapArgs))
+					{
+						previouslyModded.Add(menuMod.mapArgs);
+						validMenuMods.Add(menuMod);
+					}
+			}
+
+			foreach (var handler in validMenuMods)
+			{
+				mapMenu.AddItem(CreateMenu(handler));
+				int count = mapMenu.transform.childCount;
+				Transform lastTransform = mapMenu.transform.GetChild(count - 1);
+				RectTransform rectTransform = lastTransform.transform.GetChild(0).GetChild(0).GetComponent<RectTransform>();
+				rectTransform.sizeDelta = new Vector2(48f, 48f);
+				//Debug.Log("Set Size 48");
+			}
+		}
+
+		private MapMenu.ItemArgs CreateMenu((MapMenu.ItemArgs mapArgs, Func<NGuid, NGuid, bool> shouldAdd) handler)
+		{
+			MapMenu.ItemArgs clonedMenu = handler.mapArgs.Clone();
+			clonedMenu.Action = (mmi, obj) =>
+			{
+				pendingMenuAction = (handler.mapArgs.Action, mmi, obj);
+				menuExecutionTime = DateTime.Now.AddMilliseconds(200);
+			};
+			return clonedMenu;
+		}
+
+		/// <summary>
+		/// Fetches the last creature the menu has been open on (menu open or closed)
+		/// </summary>
+		/// <returns>NGuid for the last creature that the Radial Menu has been opened on.</returns>
+		public static NGuid GetLastRadialTargetCreature()
+		{
+			return target;
+		}
+
+		/// <summary>
+		/// Fetches the last creature the menu has been open on (menu open or closed)
+		/// </summary>
+		/// <returns>NGuid for the last creature that the Radial Menu has been opened on.</returns>
+		public static HideVolumeItem GetLastRadialHideVolume()
+		{
+			return lastHideVolumeItem;
+		}
+
+		private void AddHideVolumeEvent(Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)> dic, MapMenu map)
+		{
+			lastHideVolumeItem = Talespire.RadialMenus.GetSelectedHideVolumeItem();
+			foreach (var handlers
+					in dic.Values
+							.Where(handlers => handlers.Item2 == null
+										 || handlers.Item2(lastHideVolumeItem))) map.AddItem(handlers.Item1);
+		}
 
 
-        // Current ShortHand to see if Mini
-        private bool IsMini(string title) => title == "Emotes" || title == "Attacks";
-        private bool CanAttack(string title) => title == "Attacks";
-        private bool CanNotAttack(string title) => title == "Emotes";
+		// Current ShortHand to see if Mini
+		private bool IsMini(string title) => title == "Emotes" || title == "Attacks";
+		private bool CanAttack(string title) => title == "Attacks";
+		private bool CanNotAttack(string title) => title == "Emotes";
 
-        // Mini Submenus
-        private bool IsEmotes(string title) => title == "Twirl";
-        private bool IsKill(string title) => title == "Kill Creature";
-        private bool IsGmMenu(string title) => title == "Player Permission";
-        private bool IsAttacksMenu(string title) => title == "Attack";
-        private bool IsSizeMenu(string title) => title == "0.5x0.5";
+		// Mini Submenus
+		private bool IsEmotes(string title) => title == "Twirl";
+		private bool IsKill(string title) => title == "Kill Creature";
+		private bool IsGmMenu(string title) => title == "Player Permission";
+		private bool IsAttacksMenu(string title) => title == "Attack";
+		private bool IsSizeMenu(string title) => title == "0.5x0.5";
 
-        // Current ShortHand to see if HideVolume
-        private bool IsHideVolume(string title) => title == "Toggle Visibility";
-    }
+		// Current ShortHand to see if HideVolume
+		private bool IsHideVolume(string title) => title == "Toggle Visibility";
+	}
 }

--- a/RadialUIPlugin/RadialUIPlugin.cs
+++ b/RadialUIPlugin/RadialUIPlugin.cs
@@ -54,29 +54,227 @@ namespace RadialUI
 		private static readonly Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)> _onHideVolumeCallback = new Dictionary<string, (MapMenu.ItemArgs, Func<HideVolumeItem, bool>)>();
 
 		// Add On Character
+		[Obsolete("Use RegisterAddCharacter instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnCharacter(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCharacterCallback.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddCanAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnCanAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCanAttack.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddCantAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnCantAttack(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onCantAttack.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddSubmenuEmotes instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnSubmenuEmotes(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuEmotes.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddSubmenuKill instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnSubmenuKill(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuKill.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddSubmenuGm instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnSubmenuGm(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuGm.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddSubmenuAttacks instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnSubmenuAttacks(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuAttacks.Add(key, (value, externalCheck));
+		[Obsolete("Use RegisterAddSubmenuSize instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnSubmenuSize(string key, MapMenu.ItemArgs value, Func<NGuid, NGuid, bool> externalCheck = null) => _onSubmenuSize.Add(key, (value, externalCheck));
-
-		// Add On HideVolume
+		[Obsolete("Use RegisterAddHideVolume instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnHideVolume(string key, MapMenu.ItemArgs value, Func<HideVolumeItem, bool> externalCheck = null) => _onHideVolumeCallback.Add(key, (value, externalCheck));
 
 		// Remove On Character
+		[Obsolete("Use UnregisterAddCharacter instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnCharacter(string key) => _onCharacterCallback.Remove(key);
+		[Obsolete("Use UnregisterAddCanAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnCanAttack(string key) => _onCanAttack.Remove(key);
+		[Obsolete("Use UnregisterAddCantAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnCantAttack(string key) => _onCantAttack.Remove(key);
+		[Obsolete("Use UnregisterAddSubmenuEmotes instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnSubmenuEmotes(string key) => _onSubmenuEmotes.Remove(key);
+		[Obsolete("Use UnregisterAddSubmenuKill instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnSubmenuKill(string key) => _onSubmenuKill.Remove(key);
+		[Obsolete("Use UnregisterAddSubmenuGm instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnSubmenuGm(string key) => _onSubmenuGm.Remove(key);
+		[Obsolete("Use UnregisterAddSubmenuAttacks instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnSubmenuAttacks(string key) => _onSubmenuAttacks.Remove(key);
+		[Obsolete("Use UnregisterAddSubmenuSize instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static bool RemoveOnSubmenuSize(string key) => _onSubmenuSize.Remove(key);
 
-		
+		/// <summary>
+		/// Registers a new menu item to add to the Character menu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddCharacter(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onCharacterCallback.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the CanAttack menu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddCanAttack(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onCanAttack.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the CantAttack menu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddCantAttack(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onCantAttack.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the Emotes submenu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddSubmenuEmotes(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onSubmenuEmotes.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the Kill submenu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddSubmenuKill(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onSubmenuKill.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the GM Tools submenu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddSubmenuGm(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onSubmenuGm.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the Attacks submenu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddSubmenuAttacks(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onSubmenuAttacks.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the Size submenu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddSubmenuSize(MapMenu.ItemArgs itemArgs, Func<NGuid, NGuid, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onSubmenuSize.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a new menu item to add to the HideVolume menu.
+		/// </summary>
+		/// <param name="itemArgs">The MapMenu.ItemArgs of the menu to add (includes a callback for when this new menu item is selected).</param>
+		/// <param name="externalCheck">An optional callback to dynamically determine when you want to add the menu.</param>
+		/// <returns>Returns the commandId for this menu item add command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterAddHideVolume(MapMenu.ItemArgs itemArgs, Func<HideVolumeItem, bool> externalCheck = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			_onHideVolumeCallback.Add(commandId, (itemArgs, externalCheck));
+			return commandId;
+		}
+
+		/// <summary>
+		/// Unregisters the specified Add command from the Character menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddCharacter(string commandId) => _onCharacterCallback.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the CanAttack menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddCanAttack(string commandId) => _onCanAttack.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the CantAttack menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddCantAttack(string commandId) => _onCantAttack.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the Emotes submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddSubmenuEmotes(string commandId) => _onSubmenuEmotes.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the Kill submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddSubmenuKill(string commandId) => _onSubmenuKill.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the GM Tools submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddSubmenuGm(string commandId) => _onSubmenuGm.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the Attacks submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddSubmenuAttacks(string commandId) => _onSubmenuAttacks.Remove(commandId);
+
+		/// <summary>
+		/// Unregisters the specified Add command from the Size menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		public static bool UnregisterAddSubmenuSize(string commandId) => _onSubmenuSize.Remove(commandId);
+
+
+
 		// Add RemoveOn
 		[Obsolete("Use RegisterRemoveSubmenuAttacks instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/RadialUIPlugin/RadialUIPlugin.cs
+++ b/RadialUIPlugin/RadialUIPlugin.cs
@@ -2,6 +2,7 @@
 using Bounce.Unmanaged;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -77,26 +78,273 @@ namespace RadialUI
 
 		
 		// Add RemoveOn
+		[Obsolete("Use RegisterRemoveSubmenuAttacks instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveSubmenuAttacks(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuAttacks, key, value, callback);
+		[Obsolete("Use RegisterRemoveCanAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveCanAttack(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCanAttack, key, value, callback);
+		[Obsolete("Use RegisterRemoveCantAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveCantAttack(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCantAttack, key, value, callback);
+		[Obsolete("Use RegisterRemoveCharacter instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveCharacter(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnCharacter, key, value, callback);
+		[Obsolete("Use RegisterRemoveHideVolume instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveHideVolume(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnHideVolume, key, value, callback);
+		[Obsolete("Use RegisterRemoveSubmenuEmotes instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveSubmenuEmotes(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuEmotes, key, value, callback);
+		[Obsolete("Use RegisterRemoveSubmenuGm instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveSubmenuGm(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuGm, key, value, callback);
+		[Obsolete("Use RegisterRemoveSubmenuKill instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveSubmenuKill(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuKill, key, value, callback);
+		[Obsolete("Use RegisterRemoveSubmenuSize instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void AddOnRemoveSubmenuSize(string key, string value, ShouldShowMenu callback = null) => AddRemoveOn(_removeOnSubmenuSize, key, value, callback);
 
+
+		/// <summary>
+		/// Registers a menu item for removal from the Attacks submenu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveSubmenuAttacks(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnSubmenuAttacks, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the CanAttack menu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveCanAttack(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnCanAttack, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the CantAttack menu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveCantAttack(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnCantAttack, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the Character menu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveCharacter(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnCharacter, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the HideVolume menu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveHideVolume(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnHideVolume, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the Emotes submenu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveSubmenuEmotes(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnSubmenuEmotes, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the GM Tools submenu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveSubmenuGm(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnSubmenuGm, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the Kill submenu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveSubmenuKill(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnSubmenuKill, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+		/// <summary>
+		/// Registers a menu item for removal from the Size submenu.
+		/// </summary>
+		/// <param name="menuTitle">The title of the menu to remove.</param>
+		/// <param name="callback">An optional callback to dynamically determine when you want to remove the menu.</param>
+		/// <returns>Returns the commandId for this menu item removal command. Useful if you later want to unregister this command.</returns>
+		public static string RegisterRemoveSubmenuSize(string menuTitle, ShouldShowMenu callback = null)
+		{
+			string commandId = System.Guid.NewGuid().ToString();
+			AddRemoveOn(_removeOnSubmenuSize, commandId, menuTitle, callback);
+			return commandId;
+		}
+
+
 		// Remove RemoveOn
-		public static void RemoveOnRemoveSubmenuAttacks(string key, string value) => RemoveRemoveOn(_removeOnSubmenuAttacks, key, value);
-		public static void RemoveOnRemoveCanAttack(string key, string value) => RemoveRemoveOn(_removeOnCanAttack, key, value);
-		public static void RemoveOnRemoveCantAttack(string key, string value) => RemoveRemoveOn(_removeOnCantAttack, key, value);
-		public static void RemoveOnRemoveCharacter(string key, string value) => RemoveRemoveOn(_removeOnCharacter, key, value);
-		public static void RemoveOnRemoveHideVolume(string key, string value) => RemoveRemoveOn(_removeOnHideVolume, key, value);
-		public static void RemoveOnRemoveSubmenuEmotes(string key, string value) => RemoveRemoveOn(_removeOnSubmenuEmotes, key, value);
-		public static void RemoveOnRemoveSubmenuGm(string key, string value) => RemoveRemoveOn(_removeOnSubmenuGm, key, value);
-		public static void RemoveOnRemoveSubmenuKill(string key, string value) => RemoveRemoveOn(_removeOnSubmenuKill, key, value);
-		public static void RemoveOnRemoveSubmenuSize(string key, string value) => RemoveRemoveOn(_removeOnSubmenuSize, key, value);
+		[Obsolete("Use UnregisterRemoveSubmenuAttacks instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveSubmenuAttacks(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnSubmenuAttacks, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveCanAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveCanAttack(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnCanAttack, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveCantAttack instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveCantAttack(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnCantAttack, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveCharacter instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveCharacter(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnCharacter, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveHideVolume instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveHideVolume(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnHideVolume, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveSubmenuEmotes instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveSubmenuEmotes(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnSubmenuEmotes, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveSubmenuGm instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveSubmenuGm(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnSubmenuGm, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveSubmenuKill instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveSubmenuKill(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnSubmenuKill, commandId, menuTitle);
+		[Obsolete("Use UnregisterRemoveSubmenuSize instead.")] 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void RemoveOnRemoveSubmenuSize(string commandId, string menuTitle) => RemoveRemoveOn(_removeOnSubmenuSize, commandId, menuTitle);
+
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the Attacks submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveSubmenuAttacks(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnSubmenuAttacks, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the CanAttack menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveCanAttack(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnCanAttack, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the CantAttack menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveCantAttack(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnCantAttack, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the Character menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveCharacter(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnCharacter, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the HideVolume menu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveHideVolume(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnHideVolume, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the Emotes submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveSubmenuEmotes(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnSubmenuEmotes, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the GM Tools submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveSubmenuGm(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnSubmenuGm, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the Kill submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveSubmenuKill(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnSubmenuKill, commandId, menuTitle);
+		}
+
+		/// <summary>
+		/// Unregisters the specified Remove command from the Size submenu.
+		/// </summary>
+		/// <param name="commandId">The commandId to remove.</param>
+		/// <param name="menuTitle">An optional title of the menu to remove.</param>
+		public static void UnregisterRemoveSubmenuSize(string commandId, string menuTitle = null)
+		{
+			RemoveRemoveOn(_removeOnSubmenuSize, commandId, menuTitle);
+		}
+
 
 		private static void AddRemoveOn(Dictionary<string, List<RadialCheckRemove>> data, string key, string value, ShouldShowMenu shouldRemoveCallback)
 		{
@@ -105,13 +353,13 @@ namespace RadialUI
 			data[key].Add(new RadialCheckRemove(value, shouldRemoveCallback));
 		}
 
-		private static bool RemoveRemoveOn(Dictionary<string, List<RadialCheckRemove>> data, string key, string value)
+		private static bool RemoveRemoveOn(Dictionary<string, List<RadialCheckRemove>> data, string key, string value = null)
 		{
 			if (!data.ContainsKey(key))
 				return false;
 			List<RadialCheckRemove> radialCheckRemoves = data[key];
 			int countBefore = radialCheckRemoves.Count;
-			radialCheckRemoves.RemoveAll(x => x.TitleToRemove == value);
+			radialCheckRemoves.RemoveAll(x => value == null || x.TitleToRemove == value);  // Simply remove everthing if value is null.
 			bool successfullyRemoved = radialCheckRemoves.Count != countBefore;
 			if (radialCheckRemoves.Count == 0)
 				data.Remove(key);

--- a/RadialUIPlugin/RadialUIPlugin.csproj
+++ b/RadialUIPlugin/RadialUIPlugin.csproj
@@ -36,18 +36,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="0Harmony20">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\0Harmony20.dll</HintPath>
-    </Reference>
     <Reference Include="BepInEx, Version=5.4.9.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\BepInEx.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx.Harmony">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\BepInEx.Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="BepInEx.Preloader">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\BepInEx.Preloader.dll</HintPath>
     </Reference>
     <Reference Include="Bouncyrock.BouncePackage.Runtime">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\TaleSpire\TaleSpire_Data\Managed\Bouncyrock.BouncePackage.Runtime.dll</HintPath>
@@ -79,21 +70,9 @@
     <Reference Include="Bouncyrock.TaleSpire.Runtime">
       <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\TaleSpire\TaleSpire_Data\Managed\Bouncyrock.TaleSpire.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="HarmonyXInterop">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\HarmonyXInterop.dll</HintPath>
-    </Reference>
     <Reference Include="Mono.Cecil, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks">
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\core\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.RuntimeDetour, Version=21.1.11.1, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -105,10 +84,6 @@
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="PhotonUtil, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\AppData\Roaming\r2modmanPlus-local\TaleSpire\profiles\Default\BepInEx\plugins\HolloFox_TS-Photon_Universal_Plugin_PUP\PhotonUtil.dll</HintPath>
     </Reference>
     <Reference Include="ShapesRuntime, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -387,9 +362,12 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="RadialCheckRemove.cs" />
+    <Compile Include="RadialExtensions.cs" />
     <Compile Include="RadialUIPlugin.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RadialSubmenu.cs" />
+    <Compile Include="Talespire.RadialMenus.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/RadialUIPlugin/Talespire.RadialMenus.cs
+++ b/RadialUIPlugin/Talespire.RadialMenus.cs
@@ -1,0 +1,73 @@
+﻿using Bounce.Unmanaged;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEngine;
+
+namespace TaleSpireCore
+{
+	public static class Talespire
+	{
+		public static class RadialMenus
+		{
+			static BindingFlags bindFlags = BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+
+			public static List<MapMenu> GetAllOpen()
+			{
+				var field = MapMenuManager.Instance.GetType().GetField("_allOpenMenus", bindFlags);
+				return field.GetValue(MapMenuManager.Instance) as List<MapMenu>;
+			}
+
+			public static NGuid GetTargetCreatureId()
+			{
+				Creature targetCreature = GetTargetCreature();
+				if (targetCreature == null)
+					return NGuid.Empty;
+
+				return targetCreature.CreatureId.Value;
+			}
+
+			public static float GetHeightDiff()
+			{
+				CreatureMenuBoardTool creatureMenuBoardTool = GetCreatureMenuBoardTool();
+				if (creatureMenuBoardTool == null)
+					return 0f;
+				FieldInfo mapField = creatureMenuBoardTool.GetType().GetField("_hitHeightDif", bindFlags);
+				return (float)mapField.GetValue(creatureMenuBoardTool);
+			}
+
+			public static Creature GetTargetCreature()
+			{
+				CreatureMenuBoardTool creatureMenuBoardTool = GetCreatureMenuBoardTool();
+				FieldInfo mapField = creatureMenuBoardTool.GetType().GetField("_selectedCreature", bindFlags);
+				return mapField.GetValue(creatureMenuBoardTool) as Creature;
+			}
+
+			public static HideVolumeItem GetSelectedHideVolumeItem()
+			{
+				GMHideVolumeMenuBoardTool gmHideVolumeMenuBoardTool = GetGMHideVolumeMenuBoardTool();
+				FieldInfo mapField = gmHideVolumeMenuBoardTool.GetType().GetField("_selectedVolume", bindFlags);
+				return mapField.GetValue(gmHideVolumeMenuBoardTool) as HideVolumeItem;
+			}
+
+			// Get Pos for Hide Volume
+			public static Vector3 GetRadialTargetHideVolume()
+			{
+				GMHideVolumeMenuBoardTool gmHideVolumeMenuBoardTool = GetGMHideVolumeMenuBoardTool();
+				FieldInfo mapField = gmHideVolumeMenuBoardTool.GetType().GetField("_selectedPos", bindFlags);
+				return (Vector3)mapField.GetValue(gmHideVolumeMenuBoardTool);
+			}
+
+			public static CreatureMenuBoardTool GetCreatureMenuBoardTool()
+			{
+				return GameObject.FindObjectOfType(typeof(CreatureMenuBoardTool)) as CreatureMenuBoardTool;
+			}
+
+			public static GMHideVolumeMenuBoardTool GetGMHideVolumeMenuBoardTool()
+			{
+				return (GMHideVolumeMenuBoardTool)GameObject.FindObjectOfType(typeof(GMHideVolumeMenuBoardTool));
+			}
+		}
+	}
+}

--- a/RadialUIPlugin/Talespire.RadialMenus.cs
+++ b/RadialUIPlugin/Talespire.RadialMenus.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
-namespace TaleSpireCore
+namespace RadialUI
 {
 	public static class Talespire
 	{


### PR DESCRIPTION
Suggested naming changes to eliminate the ambiguity between different contextual uses of the words "Add" and "Remove". Also eliminated burden on users to create and pass in their own GUID (Register methods now create and return GUIDs which can be used later to Unregister the Add/Remove command if desired). Should be 100% backwards compatible. This can be simplified even further by having only three commands - RegisterNew, RegisterRemove, and Unregister. Then we use an enum for the register commands to specify which list to register the command to. Unfortunately I did not have time to take it to this level. Good luck!